### PR TITLE
Silence tests

### DIFF
--- a/lib/dnote/format.rb
+++ b/lib/dnote/format.rb
@@ -136,7 +136,12 @@ module DNote
       end
 
       def render(file)
-        erb = ERB.new(File.read(file), trim_mode: '<>')
+        contents = File.read(file)
+        erb = if RUBY_VERSION >= '2.6'
+                ERB.new(contents, trim_mode: '<>')
+              else
+                ERB.new(contents, nil, '<>')
+              end
         erb.result(binding)
       end
 

--- a/lib/dnote/format.rb
+++ b/lib/dnote/format.rb
@@ -136,7 +136,7 @@ module DNote
       end
 
       def render(file)
-        erb = ERB.new(File.read(file), nil, '<>')
+        erb = ERB.new(File.read(file), trim_mode: '<>')
         erb.result(binding)
       end
 

--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('aruba', ['~> 0.14.1'])
   s.add_development_dependency('cucumber', ['~> 3.0'])
+  s.add_development_dependency('pry', ['~> 0.12.2'])
   s.add_development_dependency('rake', ['~> 13.0'])
   s.add_development_dependency('rspec', ['~> 3.5'])
   s.add_development_dependency('simplecov', ['~> 0.17.0'])

--- a/spec/dnote/format_spec.rb
+++ b/spec/dnote/format_spec.rb
@@ -18,7 +18,8 @@ describe(DNote::Format) do
     end
 
     it 'renders the note text' do
-      expect { format.render }.to output(/Foo Text/).to_stdout
+      expect { format.render }.to output(/Foo Text/).to_stdout.
+        and output(/1 TODOs/).to_stderr
     end
   end
 end


### PR DESCRIPTION
* Silence warnings due to legacy call to `ERB.new`
* Silence extra stderr output from test