### PR TITLE
Fix coveralls dependency condition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,4 @@
 source "https://rubygems.org"
 gemspec
 
-if ENV["CI"]
-  gem "coveralls", group: :development if ENV["TRAVIS_RUBY_VERSION"] == "2.6.0"
-end
+gem "coveralls", group: :development if ENV["CI"] && ENV["TRAVIS_RUBY_VERSION"] == "2.6"


### PR DESCRIPTION
This changes the TRAVIS_RUBY_VERSION checked to a version that is actually used.