### PR TITLE
Update RuboCop config toward standardrb settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,10 @@ Style/NumericPredicate:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+# Make quoting outside and inside interpolation consistent
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
 # Prefer symbols to look like symbols
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,11 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyleForEmptyBraces: space
 
+# Use standardrb style hash literals
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBraces: no_space
+
 # Assume the programmer knows how bracketed block syntax works
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,13 +57,6 @@ Metrics/BlockLength:
     - '*.gemspec'
     - 'spec/**/*'
 
-Performance/StartWith:
-  AutoCorrect: true
-
-# Allow and/or for control flow only
-Style/AndOr:
-  EnforcedStyle: conditionals
-
 # Require at least two dependent lines before suggesting a guard clause
 Style/GuardClause:
   MinBodyLength: 2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,12 @@ AllCops:
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
 
+# Allow no extra spacing just like standardrb
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+  AllowBeforeTrailingComments: false
+  ForceEqualSignAlignment: false
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,10 +76,6 @@ Style/Next:
 Style/NumericPredicate:
   Enabled: false
 
-# Allow explicit return with multiple return values
-Style/RedundantReturn:
-  AllowMultipleReturnValues: true
-
 # Do not commit to use of interpolation
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,10 @@ Metrics/BlockLength:
     - '*.gemspec'
     - 'spec/**/*'
 
+# Use standardrb style empty methods
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 # Require at least two dependent lines before suggesting a guard clause
 Style/GuardClause:
   MinBodyLength: 2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,12 +76,6 @@ Style/Next:
 Style/NumericPredicate:
   Enabled: false
 
-# Use older RuboCop default
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    '%W': ()
-    '%w': ()
-
 # Allow explicit return with multiple return values
 Style/RedundantReturn:
   AllowMultipleReturnValues: true

--- a/lib/dnote/format.rb
+++ b/lib/dnote/format.rb
@@ -14,7 +14,7 @@ module DNote
     require "rexml/text"
     require "dnote/core_ext"
 
-    EXTENSIONS = { "text" => "txt", "soap" => "xml", "xoxo" => "xml" }.freeze
+    EXTENSIONS = {"text" => "txt", "soap" => "xml", "xoxo" => "xml"}.freeze
 
     attr_reader :notes, :format, :output, :template, :title, :dryrun
 

--- a/lib/dnote/format.rb
+++ b/lib/dnote/format.rb
@@ -34,7 +34,7 @@ module DNote
 
     def render
       if notes.empty?
-        $stderr << "No #{notes.labels.join(', ')} notes.\n"
+        $stderr << "No #{notes.labels.join(", ")} notes.\n"
       else
         case format
         when "custom"
@@ -75,7 +75,7 @@ module DNote
       else
         puts(result)
       end
-      $stderr << "(#{notes.counts.map { |l, n| "#{n} #{l}s" }.join(', ')})\n"
+      $stderr << "(#{notes.counts.map { |l, n| "#{n} #{l}s" }.join(", ")})\n"
     end
 
     def write(result, fname = nil)

--- a/lib/dnote/format.rb
+++ b/lib/dnote/format.rb
@@ -24,12 +24,12 @@ module DNote
                    template: nil,
                    output: nil,
                    dryrun: false)
-      @notes    = notes
-      @format   = format
-      @title    = title
-      @dryrun   = dryrun
+      @notes = notes
+      @format = format
+      @title = title
+      @dryrun = dryrun
       @template = template
-      @output   = output
+      @output = output
     end
 
     def render
@@ -80,8 +80,8 @@ module DNote
 
     def write(result, fname = nil)
       if output.to_s[-1, 1] == "/" || File.directory?(output)
-        fmt  = format.split("/").first
-        ext  = EXTENSIONS[fmt] || fmt
+        fmt = format.split("/").first
+        ext = EXTENSIONS[fmt] || fmt
         file = File.join(output, fname || "notes.#{ext}")
       else
         file = output

--- a/lib/dnote/note.rb
+++ b/lib/dnote/note.rb
@@ -68,12 +68,12 @@ module DNote
     # TODO: Add +code+? Problem is that xml needs code in CDATA.
     #++
     def to_h
-      { "label" => label, "text" => textline, "file" => file, "line" => line }
+      {"label" => label, "text" => textline, "file" => file, "line" => line}
     end
 
     # Convert to Hash, leaving the note text verbatim.
     def to_h_raw
-      { "label" => label, "text" => text, "file" => file, "line" => line, "code" => code }
+      {"label" => label, "text" => text, "file" => file, "line" => line, "code" => code}
     end
 
     # Convert to JSON.

--- a/lib/dnote/note.rb
+++ b/lib/dnote/note.rb
@@ -30,12 +30,12 @@ module DNote
 
     # Initialize new Note instance.
     def initialize(notes, file, label, line, text, mark)
-      @notes   = notes
-      @file    = file
-      @label   = label
-      @line    = line
-      @text    = text.rstrip
-      @mark    = mark
+      @notes = notes
+      @file = file
+      @label = label
+      @line = line
+      @text = text.rstrip
+      @mark = mark
       @capture = []
     end
 

--- a/lib/dnote/notes.rb
+++ b/lib/dnote/notes.rb
@@ -23,7 +23,7 @@ module DNote
     DEFAULT_PATHS  = ["**/*.rb"].freeze
 
     # Default note labels to look for in source code. (NOT CURRENTLY USED!)
-    DEFAULT_LABELS = %w(TODO FIXME OPTIMIZE THINK DEPRECATE).freeze
+    DEFAULT_LABELS = %w[TODO FIXME OPTIMIZE THINK DEPRECATE].freeze
 
     # Files to search for notes.
     attr_reader :files

--- a/lib/dnote/notes.rb
+++ b/lib/dnote/notes.rb
@@ -20,7 +20,7 @@ module DNote
   #++
   class Notes
     # Default paths (all ruby scripts).
-    DEFAULT_PATHS  = ["**/*.rb"].freeze
+    DEFAULT_PATHS = ["**/*.rb"].freeze
 
     # Default note labels to look for in source code. (NOT CURRENTLY USED!)
     DEFAULT_LABELS = %w[TODO FIXME OPTIMIZE THINK DEPRECATE].freeze
@@ -45,13 +45,13 @@ module DNote
 
     # New set of notes for give +files+ and optional special labels.
     def initialize(files, options = {})
-      @files   = [files].flatten
-      @labels  = [options[:labels] || DEFAULT_LABELS].flatten.compact
-      @colon   = options[:colon].nil? ? true : options[:colon]
-      @marker  = options[:marker]
-      @url     = options[:url]
+      @files = [files].flatten
+      @labels = [options[:labels] || DEFAULT_LABELS].flatten.compact
+      @colon = options[:colon].nil? ? true : options[:colon]
+      @marker = options[:marker]
+      @url = options[:url]
       @context = options[:context] || 0
-      @remark  = {}
+      @remark = {}
 
       parse
     end

--- a/lib/dnote/rake/dnotetask.rb
+++ b/lib/dnote/rake/dnotetask.rb
@@ -9,7 +9,7 @@ module DNote
     require "rake/clean"
 
     # Default note labels to looked for in source code.
-    DEFAULT_LABELS = %w(TODO FIXME OPTIMIZE DEPRECATE).freeze
+    DEFAULT_LABELS = %w[TODO FIXME OPTIMIZE DEPRECATE].freeze
 
     # File paths to search.
     attr_accessor :files

--- a/lib/dnote/rake/dnotetask.rb
+++ b/lib/dnote/rake/dnotetask.rb
@@ -97,7 +97,7 @@ module DNote
         session.format = format
       end
       session.run
-      report "Updated #{output.to_s.sub("#{Dir.pwd}/", '')}" unless trial?
+      report "Updated #{output.to_s.sub("#{Dir.pwd}/", "")}" unless trial?
     end
 
     def clean_format(format)

--- a/lib/dnote/rake/dnotetask.rb
+++ b/lib/dnote/rake/dnotetask.rb
@@ -40,10 +40,10 @@ module DNote
     def init
       require "dnote"
       require "dnote/format"
-      @files   = "**/*.rb"
-      @output  = "log/dnote"
+      @files = "**/*.rb"
+      @output = "log/dnote"
       @formats = ["index"]
-      @labels  = nil
+      @labels = nil
     end
 
     def define
@@ -79,13 +79,13 @@ module DNote
 
     def new_session
       ::DNote::Session.new do |s|
-        s.paths   = files
+        s.paths = files
         s.exclude = exclude
-        s.ignore  = ignore
-        s.labels  = labels
-        s.title   = title
-        s.output  = output
-        s.dryrun  = application.options.dryrun # trial?
+        s.ignore = ignore
+        s.labels = labels
+        s.title = title
+        s.output = output
+        s.dryrun = application.options.dryrun # trial?
       end
     end
 

--- a/lib/dnote/session.rb
+++ b/lib/dnote/session.rb
@@ -80,15 +80,15 @@ module DNote
 
     # Set default values for attributes.
     def initialize_defaults
-      @paths   = []
-      @labels  = []
+      @paths = []
+      @labels = []
       @exclude = []
-      @ignore  = []
-      @format  = DEFAULT_FORMAT
-      @title   = DEFAULT_TITLE
-      @dryrun  = false
-      @marker  = nil
-      @url     = nil
+      @ignore = []
+      @format = DEFAULT_FORMAT
+      @title = DEFAULT_TITLE
+      @dryrun = false
+      @marker = nil
+      @url = nil
       @context = 0
     end
 
@@ -148,7 +148,7 @@ module DNote
 
     # List availble format templates
     def list_templates
-      tdir   = File.join(DIR, "templates")
+      tdir = File.join(DIR, "templates")
       tfiles = Dir[File.join(tdir, "**/*.erb")]
       tnames = tfiles.map { |tname| tname.sub("#{tdir}/", "").chomp(".erb") }
       groups = tnames.group_by { |tname| tname.split("/").first }

--- a/spec/dnote/notes_collection_spec.rb
+++ b/spec/dnote/notes_collection_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe(DNote::NotesCollection) do
   describe("#by_file_label") do
     it "returns notes grouped by file then label" do
       expect(notes_collection.by_file_label)
-        .to eq("bar.rb" => { "TODO" => [bar_todo], "HACK" => [bar_hack] },
-               "foo.rb" => { "TODO" => [foo_todo], "HACK" => [foo_hack] })
+        .to eq("bar.rb" => {"TODO" => [bar_todo], "HACK" => [bar_hack]},
+               "foo.rb" => {"TODO" => [foo_todo], "HACK" => [foo_hack]})
     end
   end
 
@@ -41,8 +41,8 @@ RSpec.describe(DNote::NotesCollection) do
   describe("#by_label_file") do
     it "returns notes grouped by label then file" do
       expect(notes_collection.by_label_file)
-        .to eq("HACK" => { "bar.rb" => [bar_hack], "foo.rb" => [foo_hack] },
-               "TODO" => { "bar.rb" => [bar_todo], "foo.rb" => [foo_todo] })
+        .to eq("HACK" => {"bar.rb" => [bar_hack], "foo.rb" => [foo_hack]},
+               "TODO" => {"bar.rb" => [bar_todo], "foo.rb" => [foo_todo]})
     end
   end
 end


### PR DESCRIPTION
- Use default percent literal delimiters
- Do not allow any redundant return
- Make quoting outside and inside interpolation consistent
- Remove some redundant customization
- Expand empty methods
- Use no spaces in hash literals
- Allow no extra spacing
