### PR TITLE
Update RuboCop and handle new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Layout/ExtraSpacing:
   AllowBeforeTrailingComments: false
   ForceEqualSignAlignment: false
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/lib/dnote/format.rb
+++ b/lib/dnote/format.rb
@@ -91,7 +91,7 @@ module DNote
         puts "write: #{file}"
       else
         dir = File.dirname(file)
-        fu.mkdir(dir) unless File.exist?(dir)
+        FileUtils.mkdir_p(dir, **fu_opts)
         File.open(file, "w") { |f| f << result }
       end
       file
@@ -105,16 +105,13 @@ module DNote
       $DEBUG
     end
 
-    def fu
-      @fu ||=
-        if dryrun? && debug?
-          FileUtils::DryRun
-        elsif dryrun?
-          FileUtils::Noop
-        elsif debug?
-          FileUtils::Verbose
-        else
-          FileUtils
+    def fu_opts
+      @fu_opts ||=
+        begin
+          opts = {}
+          opts[:noop] = true if dryrun?
+          opts[:verbose] = true if debug?
+          opts
         end
     end
 

--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.26"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.9"


### PR DESCRIPTION
- Bump RuboCop version to support LineContinuationLeadingSpace config
- Configure LineContinuationLeadingSpace cop
- Fix Lint/NonAtomicFileOperation offense
