### PR TITLE
Disable RSpec/FilePath explicitly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,6 +106,10 @@ Style/SymbolArray:
 
 # Project-specific configuration goes here.
 
+# Disabled because RSpec/SpecFilePathFormat is automatically enabled as a new cop
+RSpec/FilePath:
+  Enabled: false
+
 # DNote namespace is mapped to dnote directory, both in lib and spec.
 RSpec/SpecFilePathFormat:
   CustomTransform:


### PR DESCRIPTION
This cop was re-enabled in rubocop-rspec, but the configuration for this project was already moved to RSpec/SpecFilePathFormat, so use that one instead.
