### PR TITLE
Support Rubies 3.0 through 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/mvz/dnote"
   spec.license = "BSD-2-Clause"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/dnote"


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
