### PR TITLE
Add rexml dependency

### DIFF
--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["HISTORY.rdoc", "README.md", "COPYING.rdoc"]
 
+  spec.add_dependency "rexml", "~> 3.3"
+
   spec.add_development_dependency "aruba", "~> 2.0"
   spec.add_development_dependency "cucumber", "~> 9.0"
   spec.add_development_dependency "pry", "~> 0.14.0"


### PR DESCRIPTION
This gem uses rexml. When running the tests with bundler, this dependency used to be pulled in by rubocop. However, rubocop 1.66 no longer depends on rexml, so the tests now fail when running with up-to-date dependencies.

When using the dnote tool, the absence of an explicit dependency was never a problem since rexml is a bundled gem.

This change adds an explicit dependency on rexml.
