### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/lib/dnote/notes_collection.rb
+++ b/lib/dnote/notes_collection.rb
@@ -29,8 +29,8 @@ module DNote
     end
 
     # Iterate through notes.
-    def each(&block)
-      notes.each(&block)
+    def each(&)
+      notes.each(&)
     end
 
     # No notes?

--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
     and supports almost any language.
   DESC
   spec.homepage = "https://github.com/mvz/dnote"
+
   spec.license = "BSD-2-Clause"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/dnote"

--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rexml", "~> 3.3"
 
   spec.add_development_dependency "aruba", "~> 2.0"
-  spec.add_development_dependency "cucumber", "~> 9.0"
+  spec.add_development_dependency "cucumber", "~> 9.2", ">= 9.2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
