### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/lib/dnote/note.rb
+++ b/lib/dnote/note.rb
@@ -77,13 +77,13 @@ module DNote
     end
 
     # Convert to JSON.
-    def to_json(*args)
-      to_h_raw.to_json(*args)
+    def to_json(*)
+      to_h_raw.to_json(*)
     end
 
     # Convert to YAML.
-    def to_yaml(*args)
-      to_h_raw.to_yaml(*args)
+    def to_yaml(*)
+      to_h_raw.to_yaml(*)
     end
 
     # Return line URL based on URL template. If no template was set, then

--- a/mvz-dnote.gemspec
+++ b/mvz-dnote.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/mvz/dnote"
 
   spec.license = "BSD-2-Clause"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/dnote"


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Autocorrect Style/ArgumentsForwarding**
- **Remove Ruby 3.1 from the CI matrix**
